### PR TITLE
feat: add patched version of nodejs

### DIFF
--- a/packages/all/default.nix
+++ b/packages/all/default.nix
@@ -25,9 +25,10 @@ in
 symlinkJoin {
   name = "all";
   paths = with nixsgx;[
-    container
     azure-dcap-client
+    container
     gramine
+    nodejs
     protobufc
     restart-aesmd
     sgx-dcap

--- a/packages/nodejs/default.nix
+++ b/packages/nodejs/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, callPackage
+, nodejs_18
+, libuv
+, pkgs
+, enableNpm ? false
+}:
+
+let
+  libuv_patched = libuv.overrideAttrs (prevAttrs: {
+    patches = (prevAttrs.patches or [ ]) ++ [ ./no-getifaddr.patch ];
+  });
+  callPackage' = p: args: callPackage p (args // { libuv = libuv_patched; });
+  nodejs_libuv = nodejs_18.override { callPackage = callPackage'; };
+  nodejs_patched = nodejs_libuv.overrideAttrs (prevAttrs: {
+    inherit enableNpm;
+  });
+in
+nodejs_patched

--- a/packages/nodejs/no-getifaddr.patch
+++ b/packages/nodejs/no-getifaddr.patch
@@ -1,0 +1,13 @@
+diff --git a/src/unix/linux.c b/src/unix/linux.c
+index 48b9c2c4..e3356f98 100644
+--- a/src/unix/linux.c
++++ b/src/unix/linux.c
+@@ -114,7 +114,7 @@
+ # endif
+ #endif /* __NR_getrandom */
+
+-#define HAVE_IFADDRS_H 1
++#define HAVE_IFADDRS_H 0
+
+ # if defined(__ANDROID_API__) && __ANDROID_API__ < 24
+ # undef HAVE_IFADDRS_H


### PR DESCRIPTION
getifaddr uses AF_NETLINK, which is not supported in gramine