### PR TITLE
chore(deps): update dependencies and configs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,16 +55,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
+        "lastModified": 1748437600,
+        "narHash": "sha256-hYKMs3ilp09anGO7xzfGs3JqEgUqFMnZ8GMAqI6/k04=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
+        "rev": "7282cb574e0607e65224d33be8241eae7cfe0979",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
 
     snowfall-lib = {
       url = "github:snowfallorg/lib?ref=c6238c83de101729c5de3a29586ba166a9a65622";

--- a/packages/nodejs/default.nix
+++ b/packages/nodejs/default.nix
@@ -1,5 +1,5 @@
-{ nodejs_18, enableNpm ? false }:
-nodejs_18.overrideAttrs (prevAttrs: {
+{ nodejs_24, enableNpm ? false }:
+nodejs_24.overrideAttrs (prevAttrs: {
   inherit enableNpm;
   configureFlags = prevAttrs.configureFlags ++ [ "--without-node-snapshot" ];
 })

--- a/packages/sgx-sdk/default.nix
+++ b/packages/sgx-sdk/default.nix
@@ -146,13 +146,21 @@ stdenv.mkDerivation rec {
       popd
     '';
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=missing-include-dirs";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=missing-include-dirs -Wno-error=implicit-fallthrough -Wno-error=implicit-int -Wno-error=declaration-missing-parameter-type";
 
   buildFlags = [
     "sdk_install_pkg"
+    "COMMON_FLAGS+=-Wno-error=missing-include-dirs"
+    "COMMON_FLAGS+=-Wno-error=implicit-fallthrough"
+    "COMMON_FLAGS+=-Wno-error=implicit-int"
+    "COMMON_FLAGS+=-Wno-error=declaration-missing-parameter-type"
+    "V=1"
   ] ++ lib.optionals debug [
     "DEBUG=1"
   ];
+
+  # sigh! Intel
+  enableParallelBuilding = false;
 
   postBuild = ''
     patchShebangs linux/installer/bin/sgx_linux_x64_sdk_${version}.bin


### PR DESCRIPTION
- Update nixpkgs to 25.05 and Node.js to version 24.
- Adjust SGX SDK build flags to suppress additional warnings.
- Disable parallel building for SGX SDK due to Intel constraints.