### PR TITLE
feat: add sgx-dcap-quoteverify package for non-x86 platforms

### DIFF
--- a/packages/sgx-dcap-quoteverify/default.nix
+++ b/packages/sgx-dcap-quoteverify/default.nix
@@ -1,0 +1,228 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  openssl,
+}:
+let
+  version = "1.25";
+
+  dcapSrc = fetchFromGitHub {
+    owner = "intel";
+    repo = "confidential-computing.tee.dcap";
+    rev = "DCAP_${version}";
+    hash = "sha256-EXfQ1nOt8IP09N4yKUeQmlbAbr/4FXoToAnBNcQb2dM=";
+    fetchSubmodules = true;
+  };
+
+  sgxSdkSrc = fetchFromGitHub {
+    owner = "intel";
+    repo = "confidential-computing.sgx";
+    rev = "sgx_2.28";
+    hash = "sha256-dRLTyIMNHnPmHb+ro2O7UtzR5EkhMXvxR5BKa6kfNhs=";
+    fetchSubmodules = false;
+  };
+in
+stdenv.mkDerivation {
+  pname = "sgx-dcap-quoteverify";
+  inherit version;
+
+  src = dcapSrc;
+
+  buildInputs = [
+    openssl
+  ];
+
+  postPatch = ''
+    patchShebangs --build $(find . -name '*.sh')
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # --- Directories ---
+    export DCAP_SRC=$PWD
+    export SGX_SDK_SRC=${sgxSdkSrc}
+    export OPENSSL_INC=${openssl.dev}/include
+    export OPENSSL_LIB=${lib.getLib openssl}/lib
+
+    # --- Create a fake SGX SDK layout with just the headers ---
+    export SGX_SDK=$TMPDIR/sgx-sdk
+    mkdir -p $SGX_SDK/include/internal
+    cp -r $SGX_SDK_SRC/common/inc/*.h $SGX_SDK/include/
+    cp -r $SGX_SDK_SRC/common/inc/internal/*.h $SGX_SDK/include/internal/
+
+    # --- Create a fake SGXSSL layout ---
+    export SGXSSL_PACKAGE_PATH=$TMPDIR/sgxssl
+    mkdir -p $SGXSSL_PACKAGE_PATH/lib64
+    $CC -c -fPIC ${./sgxssl_stub.c} -o $TMPDIR/sgxssl_stub.o
+    $AR rsD $SGXSSL_PACKAGE_PATH/lib64/libsgx_usgxssl.a $TMPDIR/sgxssl_stub.o
+
+    # --- Create a fake prebuilt OpenSSL layout ---
+    export PREBUILD_OPENSSL=$TMPDIR/prebuilt-openssl
+    mkdir -p $PREBUILD_OPENSSL/inc $PREBUILD_OPENSSL/lib/linux64
+    ln -s $OPENSSL_INC/openssl $PREBUILD_OPENSSL/inc/openssl
+    ln -s $OPENSSL_LIB/libcrypto.a $PREBUILD_OPENSSL/lib/linux64/libcrypto.a \
+      || ln -s $OPENSSL_LIB/libcrypto.so $PREBUILD_OPENSSL/lib/linux64/libcrypto.so
+
+    # --- Copy pre-generated edger8r files ---
+    cp ${./qve_u.c} QuoteVerification/dcap_quoteverify/linux/qve_u.c
+    cp ${./qve_u.h} QuoteVerification/dcap_quoteverify/linux/qve_u.h
+
+    # --- Determine version strings ---
+    SGX_VER=$(awk '/#define STRFILEVER/ { gsub(/"/, "", $3); print $3 }' \
+      QuoteGeneration/common/inc/internal/se_version.h)
+    SGX_MAJOR_VER=$(echo $SGX_VER | cut -d. -f1)
+
+    # --- Common flags ---
+    COMMON_FLAGS="-O2 -ffunction-sections -fdata-sections -fstack-protector-strong"
+    COMMON_FLAGS="$COMMON_FLAGS -D_GLIBCXX_ASSERTIONS -DNDEBUG"
+    COMMON_FLAGS="$COMMON_FLAGS -Wall -Wextra -fPIC -USGX_TRUSTED"
+    COMMON_LDFLAGS="-Wl,-z,relro,-z,now,-z,noexecstack"
+
+    # Include paths
+    QG_DIR=$DCAP_SRC/QuoteGeneration
+    QV_DIR=$DCAP_SRC/QuoteVerification
+    QVL_SRC=$QV_DIR/QVL/Src
+    QVE_SRC=$DCAP_SRC/ae/QvE
+    EXTERNAL_DIR=$DCAP_SRC/external
+
+    QVL_LIB_PATH=$QVL_SRC/AttestationLibrary
+    QVL_PARSER_PATH=$QVL_SRC/AttestationParsers
+    QVL_COMMON_PATH=$QVL_SRC/AttestationCommons
+
+    QVL_LIB_INC="-I$QVL_COMMON_PATH/include -I$QVL_COMMON_PATH/include/Utils \
+      -I$QVL_LIB_PATH/include -I$QVL_LIB_PATH/src \
+      -I$QVL_PARSER_PATH/include -I$QVL_SRC/ThirdParty/rapidjson/include \
+      -isystem$EXTERNAL_DIR/jwt-cpp/include \
+      -I$PREBUILD_OPENSSL/inc -I$QVE_SRC/Include"
+
+    QVL_PARSER_INC="-I$QVL_COMMON_PATH/include -I$QVL_COMMON_PATH/include/Utils \
+      -I$QVL_SRC -I$QVL_PARSER_PATH/include -I$QVL_PARSER_PATH/src \
+      -I$QVL_LIB_PATH/include \
+      -isystem$QVL_SRC/ThirdParty/rapidjson/include \
+      -I$PREBUILD_OPENSSL/inc"
+
+    QVL_VERIFY_INC="-I$QVE_SRC/Include \
+      -I$QV_DIR/dcap_quoteverify/inc \
+      -I$QG_DIR/quote_wrapper/common/inc \
+      -I$SGX_SDK/include \
+      -I$QG_DIR/common/inc/internal \
+      -I$QG_DIR/common/inc/internal/linux \
+      -I$QG_DIR/pce_wrapper/inc \
+      -I$PREBUILD_OPENSSL/inc \
+      $QVL_LIB_INC \
+      -I$QG_DIR/qpl/inc \
+      -I$QV_DIR/appraisal/common \
+      -I$QV_DIR/appraisal/qal"
+
+    CFLAGS_COMMON="$COMMON_FLAGS -Wjump-misses-init -Wstrict-prototypes -Wunsuffixed-float-constants"
+    CXXFLAGS_COMMON="$COMMON_FLAGS -Wnon-virtual-dtor -std=c++17"
+
+    # --- Build QVL Attestation Library (untrusted) ---
+    echo "Building QVL AttestationLibrary..."
+    QVL_LIB_FILES=$(find $QVL_LIB_PATH/src -name '*.cpp' | sort)
+    QVL_COMMON_FILES=$(find $QVL_COMMON_PATH/src/Utils -name '*.cpp' | sort)
+    QVL_LIB_OBJS=""
+    for src in $QVL_LIB_FILES $QVL_COMMON_FILES; do
+      obj=$TMPDIR/qvl_lib/$(basename $src .cpp)_untrusted.o
+      mkdir -p $TMPDIR/qvl_lib
+      $CXX $CXXFLAGS_COMMON $QVL_LIB_INC -c $src -o $obj
+      QVL_LIB_OBJS="$QVL_LIB_OBJS $obj"
+    done
+    $AR rsD $TMPDIR/libsgx_dcap_qvl_parser.a $QVL_LIB_OBJS
+
+    # --- Build QVL Attestation Parsers (untrusted) ---
+    echo "Building QVL AttestationParsers..."
+    QVL_PARSER_FILES=$(find $QVL_PARSER_PATH/src -name '*.cpp' | sort)
+    QVL_PARSER_OBJS=""
+    for src in $QVL_PARSER_FILES; do
+      obj=$TMPDIR/qvl_parser/$(basename $src .cpp)_untrusted.o
+      mkdir -p $TMPDIR/qvl_parser
+      $CXX $CXXFLAGS_COMMON $QVL_PARSER_INC -c $src -o $obj
+      QVL_PARSER_OBJS="$QVL_PARSER_OBJS $obj"
+    done
+    $AR rsD $TMPDIR/libsgx_dcap_qvl_attestation.a $QVL_PARSER_OBJS
+
+    # --- Build quoteverify library ---
+    echo "Building libsgx_dcap_quoteverify.so..."
+    QV_LINUX=$QV_DIR/dcap_quoteverify/linux
+    VERIFY_OBJS=""
+
+    # C++ sources from dcap_quoteverify/ and dcap_quoteverify/linux/
+    for src in $(find $QV_DIR/dcap_quoteverify -maxdepth 1 -name '*.cpp' | sort) \
+               $(find $QV_LINUX -maxdepth 1 -name '*.cpp' | sort); do
+      obj=$TMPDIR/qv/$(basename $src .cpp).o
+      mkdir -p $TMPDIR/qv
+      $CXX $CXXFLAGS_COMMON $QVL_VERIFY_INC -c $src -o $obj
+      VERIFY_OBJS="$VERIFY_OBJS $obj"
+    done
+
+    # C sources
+    COMMON_DIR=$QG_DIR/common
+    $CC $CFLAGS_COMMON $QVL_VERIFY_INC -c $COMMON_DIR/src/se_trace.c -o $TMPDIR/qv/se_trace.o
+    $CC $CFLAGS_COMMON $QVL_VERIFY_INC -c $COMMON_DIR/src/se_thread.c -o $TMPDIR/qv/se_thread.o
+    $CC $CFLAGS_COMMON $QVL_VERIFY_INC -c $QV_LINUX/qve_u.c -o $TMPDIR/qv/qve_u.o
+    VERIFY_OBJS="$VERIFY_OBJS $TMPDIR/qv/se_trace.o $TMPDIR/qv/se_thread.o $TMPDIR/qv/qve_u.o"
+
+    # QvE untrusted wrapper objects
+    $CXX $CXXFLAGS_COMMON $QVL_VERIFY_INC -c $QVE_SRC/qve/qve.cpp -o $TMPDIR/qv/untrusted_qve.o
+    $CXX $CXXFLAGS_COMMON $QVL_VERIFY_INC -c $QVE_SRC/qve/qve_logic.cpp -o $TMPDIR/qv/untrusted_qve_logic.o
+    VERIFY_OBJS="$VERIFY_OBJS $TMPDIR/qv/untrusted_qve.o $TMPDIR/qv/untrusted_qve_logic.o"
+
+    # Common lib objects
+    $CXX $CXXFLAGS_COMMON $QVL_VERIFY_INC -c $QG_DIR/qpl/sgx_base64.cpp -o $TMPDIR/qv/sgx_base64.o
+    $CXX $CXXFLAGS_COMMON $QVL_VERIFY_INC -c $QV_DIR/appraisal/common/ec_key.cpp -o $TMPDIR/qv/ec_key.o
+    VERIFY_OBJS="$VERIFY_OBJS $TMPDIR/qv/sgx_base64.o $TMPDIR/qv/ec_key.o"
+
+    # Link everything
+    $CXX $CXXFLAGS_COMMON \
+      $VERIFY_OBJS \
+      -L$SGXSSL_PACKAGE_PATH/lib64 -lsgx_usgxssl \
+      -L$TMPDIR -lsgx_dcap_qvl_parser -lsgx_dcap_qvl_attestation \
+      -L$PREBUILD_OPENSSL/lib/linux64 -lcrypto \
+      -shared -Wl,-soname=libsgx_dcap_quoteverify.so.$SGX_MAJOR_VER \
+      -Wl,--version-script=$QV_LINUX/sgx_dcap_quoteverify.lds \
+      -Wl,--gc-sections \
+      $COMMON_LDFLAGS \
+      -pthread -ldl \
+      -o $TMPDIR/libsgx_dcap_quoteverify.so
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    SGX_VER=$(awk '/#define STRFILEVER/ { gsub(/"/, "", $3); print $3 }' \
+      QuoteGeneration/common/inc/internal/se_version.h)
+    SGX_MAJOR_VER=$(echo $SGX_VER | cut -d. -f1)
+
+    mkdir -p $out/lib $out/include
+
+    cp $TMPDIR/libsgx_dcap_quoteverify.so $out/lib/libsgx_dcap_quoteverify.so.$SGX_VER
+    ln -s libsgx_dcap_quoteverify.so.$SGX_VER $out/lib/libsgx_dcap_quoteverify.so.$SGX_MAJOR_VER
+    ln -s libsgx_dcap_quoteverify.so.$SGX_MAJOR_VER $out/lib/libsgx_dcap_quoteverify.so
+
+    # Install public headers
+    cp QuoteVerification/dcap_quoteverify/inc/sgx_dcap_quoteverify.h $out/include/
+    cp QuoteGeneration/quote_wrapper/common/inc/sgx_ql_quote.h $out/include/
+    cp ae/QvE/Include/sgx_qve_header.h $out/include/
+    cp ae/QvE/Include/sgx_qve_def.h $out/include/
+
+    runHook postInstall
+  '';
+
+  dontUseCmakeConfigure = true;
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Intel(R) SGX DCAP Quote Verification Library";
+    homepage = "https://github.com/intel/confidential-computing.tee.dcap";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    license = with licenses; [ bsd3 ];
+  };
+}

--- a/packages/sgx-dcap-quoteverify/qve_u.c
+++ b/packages/sgx-dcap-quoteverify/qve_u.c
@@ -1,0 +1,272 @@
+#include "qve_u.h"
+#include <errno.h>
+
+typedef struct ms_get_fmspc_ca_from_quote_t {
+	quote3_error_t ms_retval;
+	const uint8_t* ms_quote;
+	uint32_t ms_quote_size;
+	unsigned char* ms_fmsp_from_quote;
+	uint32_t ms_fmsp_from_quote_size;
+	unsigned char* ms_ca_from_quote;
+	uint32_t ms_ca_from_quote_size;
+} ms_get_fmspc_ca_from_quote_t;
+
+typedef struct ms_sgx_qve_get_quote_supplemental_data_size_t {
+	quote3_error_t ms_retval;
+	uint32_t* ms_p_data_size;
+} ms_sgx_qve_get_quote_supplemental_data_size_t;
+
+typedef struct ms_sgx_qve_get_quote_supplemental_data_version_t {
+	quote3_error_t ms_retval;
+	uint32_t* ms_p_version;
+} ms_sgx_qve_get_quote_supplemental_data_version_t;
+
+typedef struct ms_sgx_qve_verify_quote_t {
+	quote3_error_t ms_retval;
+	const uint8_t* ms_p_quote;
+	uint32_t ms_quote_size;
+	const struct _sgx_ql_qve_collateral_t* ms_p_quote_collateral;
+	time_t ms_expiration_check_date;
+	uint32_t* ms_p_collateral_expiration_status;
+	sgx_ql_qv_result_t* ms_p_quote_verification_result;
+	sgx_ql_qe_report_info_t* ms_p_qve_report_info;
+	uint32_t ms_supplemental_data_size;
+	uint8_t* ms_p_supplemental_data;
+} ms_sgx_qve_verify_quote_t;
+
+typedef struct ms_tee_qve_verify_quote_qvt_t {
+	quote3_error_t ms_retval;
+	const uint8_t* ms_p_quote;
+	uint32_t ms_quote_size;
+	time_t ms_current_time;
+	const struct _sgx_ql_qve_collateral_t* ms_p_quote_collateral;
+	sgx_ql_qe_report_info_t* ms_p_qve_report_info;
+	const uint8_t* ms_p_user_data;
+	uint32_t ms_user_data_size;
+	uint32_t* ms_p_verification_result_token_buffer_size;
+	uint8_t** ms_p_verification_result_token;
+} ms_tee_qve_verify_quote_qvt_t;
+
+typedef struct ms_ocall_qvt_token_malloc_t {
+	uint64_t ms_verification_result_token_buffer_size;
+	uint8_t** ms_p_verification_result_token;
+} ms_ocall_qvt_token_malloc_t;
+
+typedef struct ms_sgx_oc_cpuidex_t {
+	int* ms_cpuinfo;
+	int ms_leaf;
+	int ms_subleaf;
+} ms_sgx_oc_cpuidex_t;
+
+typedef struct ms_sgx_thread_wait_untrusted_event_ocall_t {
+	int ms_retval;
+	const void* ms_self;
+} ms_sgx_thread_wait_untrusted_event_ocall_t;
+
+typedef struct ms_sgx_thread_set_untrusted_event_ocall_t {
+	int ms_retval;
+	const void* ms_waiter;
+} ms_sgx_thread_set_untrusted_event_ocall_t;
+
+typedef struct ms_sgx_thread_setwait_untrusted_events_ocall_t {
+	int ms_retval;
+	const void* ms_waiter;
+	const void* ms_self;
+} ms_sgx_thread_setwait_untrusted_events_ocall_t;
+
+typedef struct ms_sgx_thread_set_multiple_untrusted_events_ocall_t {
+	int ms_retval;
+	const void** ms_waiters;
+	size_t ms_total;
+} ms_sgx_thread_set_multiple_untrusted_events_ocall_t;
+
+typedef struct ms_u_sgxssl_ftime_t {
+	void* ms_timeptr;
+	uint32_t ms_timeb_len;
+} ms_u_sgxssl_ftime_t;
+
+typedef struct ms_pthread_wait_timeout_ocall_t {
+	int ms_retval;
+	unsigned long long ms_waiter;
+	unsigned long long ms_timeout;
+} ms_pthread_wait_timeout_ocall_t;
+
+typedef struct ms_pthread_create_ocall_t {
+	int ms_retval;
+	unsigned long long ms_self;
+} ms_pthread_create_ocall_t;
+
+typedef struct ms_pthread_wakeup_ocall_t {
+	int ms_retval;
+	unsigned long long ms_waiter;
+} ms_pthread_wakeup_ocall_t;
+
+static sgx_status_t SGX_CDECL qve_ocall_qvt_token_malloc(void* pms)
+{
+	ms_ocall_qvt_token_malloc_t* ms = SGX_CAST(ms_ocall_qvt_token_malloc_t*, pms);
+	ocall_qvt_token_malloc(ms->ms_verification_result_token_buffer_size, ms->ms_p_verification_result_token);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_sgx_oc_cpuidex(void* pms)
+{
+	ms_sgx_oc_cpuidex_t* ms = SGX_CAST(ms_sgx_oc_cpuidex_t*, pms);
+	sgx_oc_cpuidex(ms->ms_cpuinfo, ms->ms_leaf, ms->ms_subleaf);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_sgx_thread_wait_untrusted_event_ocall(void* pms)
+{
+	ms_sgx_thread_wait_untrusted_event_ocall_t* ms = SGX_CAST(ms_sgx_thread_wait_untrusted_event_ocall_t*, pms);
+	ms->ms_retval = sgx_thread_wait_untrusted_event_ocall(ms->ms_self);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_sgx_thread_set_untrusted_event_ocall(void* pms)
+{
+	ms_sgx_thread_set_untrusted_event_ocall_t* ms = SGX_CAST(ms_sgx_thread_set_untrusted_event_ocall_t*, pms);
+	ms->ms_retval = sgx_thread_set_untrusted_event_ocall(ms->ms_waiter);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_sgx_thread_setwait_untrusted_events_ocall(void* pms)
+{
+	ms_sgx_thread_setwait_untrusted_events_ocall_t* ms = SGX_CAST(ms_sgx_thread_setwait_untrusted_events_ocall_t*, pms);
+	ms->ms_retval = sgx_thread_setwait_untrusted_events_ocall(ms->ms_waiter, ms->ms_self);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_sgx_thread_set_multiple_untrusted_events_ocall(void* pms)
+{
+	ms_sgx_thread_set_multiple_untrusted_events_ocall_t* ms = SGX_CAST(ms_sgx_thread_set_multiple_untrusted_events_ocall_t*, pms);
+	ms->ms_retval = sgx_thread_set_multiple_untrusted_events_ocall(ms->ms_waiters, ms->ms_total);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_u_sgxssl_ftime(void* pms)
+{
+	ms_u_sgxssl_ftime_t* ms = SGX_CAST(ms_u_sgxssl_ftime_t*, pms);
+	u_sgxssl_ftime(ms->ms_timeptr, ms->ms_timeb_len);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_pthread_wait_timeout_ocall(void* pms)
+{
+	ms_pthread_wait_timeout_ocall_t* ms = SGX_CAST(ms_pthread_wait_timeout_ocall_t*, pms);
+	ms->ms_retval = pthread_wait_timeout_ocall(ms->ms_waiter, ms->ms_timeout);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_pthread_create_ocall(void* pms)
+{
+	ms_pthread_create_ocall_t* ms = SGX_CAST(ms_pthread_create_ocall_t*, pms);
+	ms->ms_retval = pthread_create_ocall(ms->ms_self);
+
+	return SGX_SUCCESS;
+}
+
+static sgx_status_t SGX_CDECL qve_pthread_wakeup_ocall(void* pms)
+{
+	ms_pthread_wakeup_ocall_t* ms = SGX_CAST(ms_pthread_wakeup_ocall_t*, pms);
+	ms->ms_retval = pthread_wakeup_ocall(ms->ms_waiter);
+
+	return SGX_SUCCESS;
+}
+
+static const struct {
+	size_t nr_ocall;
+	void * table[10];
+} ocall_table_qve = {
+	10,
+	{
+		(void*)qve_ocall_qvt_token_malloc,
+		(void*)qve_sgx_oc_cpuidex,
+		(void*)qve_sgx_thread_wait_untrusted_event_ocall,
+		(void*)qve_sgx_thread_set_untrusted_event_ocall,
+		(void*)qve_sgx_thread_setwait_untrusted_events_ocall,
+		(void*)qve_sgx_thread_set_multiple_untrusted_events_ocall,
+		(void*)qve_u_sgxssl_ftime,
+		(void*)qve_pthread_wait_timeout_ocall,
+		(void*)qve_pthread_create_ocall,
+		(void*)qve_pthread_wakeup_ocall,
+	}
+};
+sgx_status_t get_fmspc_ca_from_quote(sgx_enclave_id_t eid, quote3_error_t* retval, const uint8_t* quote, uint32_t quote_size, unsigned char* fmsp_from_quote, uint32_t fmsp_from_quote_size, unsigned char* ca_from_quote, uint32_t ca_from_quote_size)
+{
+	sgx_status_t status;
+	ms_get_fmspc_ca_from_quote_t ms;
+	ms.ms_quote = quote;
+	ms.ms_quote_size = quote_size;
+	ms.ms_fmsp_from_quote = fmsp_from_quote;
+	ms.ms_fmsp_from_quote_size = fmsp_from_quote_size;
+	ms.ms_ca_from_quote = ca_from_quote;
+	ms.ms_ca_from_quote_size = ca_from_quote_size;
+	status = sgx_ecall(eid, 0, &ocall_table_qve, &ms);
+	if (status == SGX_SUCCESS && retval) *retval = ms.ms_retval;
+	return status;
+}
+
+sgx_status_t sgx_qve_get_quote_supplemental_data_size(sgx_enclave_id_t eid, quote3_error_t* retval, uint32_t* p_data_size)
+{
+	sgx_status_t status;
+	ms_sgx_qve_get_quote_supplemental_data_size_t ms;
+	ms.ms_p_data_size = p_data_size;
+	status = sgx_ecall(eid, 1, &ocall_table_qve, &ms);
+	if (status == SGX_SUCCESS && retval) *retval = ms.ms_retval;
+	return status;
+}
+
+sgx_status_t sgx_qve_get_quote_supplemental_data_version(sgx_enclave_id_t eid, quote3_error_t* retval, uint32_t* p_version)
+{
+	sgx_status_t status;
+	ms_sgx_qve_get_quote_supplemental_data_version_t ms;
+	ms.ms_p_version = p_version;
+	status = sgx_ecall(eid, 2, &ocall_table_qve, &ms);
+	if (status == SGX_SUCCESS && retval) *retval = ms.ms_retval;
+	return status;
+}
+
+sgx_status_t sgx_qve_verify_quote(sgx_enclave_id_t eid, quote3_error_t* retval, const uint8_t* p_quote, uint32_t quote_size, const struct _sgx_ql_qve_collateral_t* p_quote_collateral, time_t expiration_check_date, uint32_t* p_collateral_expiration_status, sgx_ql_qv_result_t* p_quote_verification_result, sgx_ql_qe_report_info_t* p_qve_report_info, uint32_t supplemental_data_size, uint8_t* p_supplemental_data)
+{
+	sgx_status_t status;
+	ms_sgx_qve_verify_quote_t ms;
+	ms.ms_p_quote = p_quote;
+	ms.ms_quote_size = quote_size;
+	ms.ms_p_quote_collateral = p_quote_collateral;
+	ms.ms_expiration_check_date = expiration_check_date;
+	ms.ms_p_collateral_expiration_status = p_collateral_expiration_status;
+	ms.ms_p_quote_verification_result = p_quote_verification_result;
+	ms.ms_p_qve_report_info = p_qve_report_info;
+	ms.ms_supplemental_data_size = supplemental_data_size;
+	ms.ms_p_supplemental_data = p_supplemental_data;
+	status = sgx_ecall(eid, 3, &ocall_table_qve, &ms);
+	if (status == SGX_SUCCESS && retval) *retval = ms.ms_retval;
+	return status;
+}
+
+sgx_status_t tee_qve_verify_quote_qvt(sgx_enclave_id_t eid, quote3_error_t* retval, const uint8_t* p_quote, uint32_t quote_size, time_t current_time, const struct _sgx_ql_qve_collateral_t* p_quote_collateral, sgx_ql_qe_report_info_t* p_qve_report_info, const uint8_t* p_user_data, uint32_t user_data_size, uint32_t* p_verification_result_token_buffer_size, uint8_t** p_verification_result_token)
+{
+	sgx_status_t status;
+	ms_tee_qve_verify_quote_qvt_t ms;
+	ms.ms_p_quote = p_quote;
+	ms.ms_quote_size = quote_size;
+	ms.ms_current_time = current_time;
+	ms.ms_p_quote_collateral = p_quote_collateral;
+	ms.ms_p_qve_report_info = p_qve_report_info;
+	ms.ms_p_user_data = p_user_data;
+	ms.ms_user_data_size = user_data_size;
+	ms.ms_p_verification_result_token_buffer_size = p_verification_result_token_buffer_size;
+	ms.ms_p_verification_result_token = p_verification_result_token;
+	status = sgx_ecall(eid, 4, &ocall_table_qve, &ms);
+	if (status == SGX_SUCCESS && retval) *retval = ms.ms_retval;
+	return status;
+}
+

--- a/packages/sgx-dcap-quoteverify/qve_u.h
+++ b/packages/sgx-dcap-quoteverify/qve_u.h
@@ -1,0 +1,94 @@
+#ifndef QVE_U_H__
+#define QVE_U_H__
+
+#include <stdint.h>
+#include <wchar.h>
+#include <stddef.h>
+#include <string.h>
+#include "sgx_edger8r.h" /* for sgx_status_t etc. */
+
+#include "sgx_qve_header.h"
+#include "sgx_qve_def.h"
+
+#include <stdlib.h> /* for size_t */
+
+#define SGX_CAST(type, item) ((type)(item))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __sgx_ql_qve_collateral_t
+#define __sgx_ql_qve_collateral_t
+typedef struct _sgx_ql_qve_collateral_t {
+	uint32_t version;
+	uint32_t tee_type;
+	char* pck_crl_issuer_chain;
+	uint32_t pck_crl_issuer_chain_size;
+	char* root_ca_crl;
+	uint32_t root_ca_crl_size;
+	char* pck_crl;
+	uint32_t pck_crl_size;
+	char* tcb_info_issuer_chain;
+	uint32_t tcb_info_issuer_chain_size;
+	char* tcb_info;
+	uint32_t tcb_info_size;
+	char* qe_identity_issuer_chain;
+	uint32_t qe_identity_issuer_chain_size;
+	char* qe_identity;
+	uint32_t qe_identity_size;
+} _sgx_ql_qve_collateral_t;
+#endif
+
+#ifndef OCALL_QVT_TOKEN_MALLOC_DEFINED__
+#define OCALL_QVT_TOKEN_MALLOC_DEFINED__
+void SGX_UBRIDGE(SGX_NOCONVENTION, ocall_qvt_token_malloc, (uint64_t verification_result_token_buffer_size, uint8_t** p_verification_result_token));
+#endif
+#ifndef SGX_OC_CPUIDEX_DEFINED__
+#define SGX_OC_CPUIDEX_DEFINED__
+void SGX_UBRIDGE(SGX_CDECL, sgx_oc_cpuidex, (int cpuinfo[4], int leaf, int subleaf));
+#endif
+#ifndef SGX_THREAD_WAIT_UNTRUSTED_EVENT_OCALL_DEFINED__
+#define SGX_THREAD_WAIT_UNTRUSTED_EVENT_OCALL_DEFINED__
+int SGX_UBRIDGE(SGX_CDECL, sgx_thread_wait_untrusted_event_ocall, (const void* self));
+#endif
+#ifndef SGX_THREAD_SET_UNTRUSTED_EVENT_OCALL_DEFINED__
+#define SGX_THREAD_SET_UNTRUSTED_EVENT_OCALL_DEFINED__
+int SGX_UBRIDGE(SGX_CDECL, sgx_thread_set_untrusted_event_ocall, (const void* waiter));
+#endif
+#ifndef SGX_THREAD_SETWAIT_UNTRUSTED_EVENTS_OCALL_DEFINED__
+#define SGX_THREAD_SETWAIT_UNTRUSTED_EVENTS_OCALL_DEFINED__
+int SGX_UBRIDGE(SGX_CDECL, sgx_thread_setwait_untrusted_events_ocall, (const void* waiter, const void* self));
+#endif
+#ifndef SGX_THREAD_SET_MULTIPLE_UNTRUSTED_EVENTS_OCALL_DEFINED__
+#define SGX_THREAD_SET_MULTIPLE_UNTRUSTED_EVENTS_OCALL_DEFINED__
+int SGX_UBRIDGE(SGX_CDECL, sgx_thread_set_multiple_untrusted_events_ocall, (const void** waiters, size_t total));
+#endif
+#ifndef U_SGXSSL_FTIME_DEFINED__
+#define U_SGXSSL_FTIME_DEFINED__
+void SGX_UBRIDGE(SGX_NOCONVENTION, u_sgxssl_ftime, (void* timeptr, uint32_t timeb_len));
+#endif
+#ifndef PTHREAD_WAIT_TIMEOUT_OCALL_DEFINED__
+#define PTHREAD_WAIT_TIMEOUT_OCALL_DEFINED__
+int SGX_UBRIDGE(SGX_CDECL, pthread_wait_timeout_ocall, (unsigned long long waiter, unsigned long long timeout));
+#endif
+#ifndef PTHREAD_CREATE_OCALL_DEFINED__
+#define PTHREAD_CREATE_OCALL_DEFINED__
+int SGX_UBRIDGE(SGX_CDECL, pthread_create_ocall, (unsigned long long self));
+#endif
+#ifndef PTHREAD_WAKEUP_OCALL_DEFINED__
+#define PTHREAD_WAKEUP_OCALL_DEFINED__
+int SGX_UBRIDGE(SGX_CDECL, pthread_wakeup_ocall, (unsigned long long waiter));
+#endif
+
+sgx_status_t get_fmspc_ca_from_quote(sgx_enclave_id_t eid, quote3_error_t* retval, const uint8_t* quote, uint32_t quote_size, unsigned char* fmsp_from_quote, uint32_t fmsp_from_quote_size, unsigned char* ca_from_quote, uint32_t ca_from_quote_size);
+sgx_status_t sgx_qve_get_quote_supplemental_data_size(sgx_enclave_id_t eid, quote3_error_t* retval, uint32_t* p_data_size);
+sgx_status_t sgx_qve_get_quote_supplemental_data_version(sgx_enclave_id_t eid, quote3_error_t* retval, uint32_t* p_version);
+sgx_status_t sgx_qve_verify_quote(sgx_enclave_id_t eid, quote3_error_t* retval, const uint8_t* p_quote, uint32_t quote_size, const struct _sgx_ql_qve_collateral_t* p_quote_collateral, time_t expiration_check_date, uint32_t* p_collateral_expiration_status, sgx_ql_qv_result_t* p_quote_verification_result, sgx_ql_qe_report_info_t* p_qve_report_info, uint32_t supplemental_data_size, uint8_t* p_supplemental_data);
+sgx_status_t tee_qve_verify_quote_qvt(sgx_enclave_id_t eid, quote3_error_t* retval, const uint8_t* p_quote, uint32_t quote_size, time_t current_time, const struct _sgx_ql_qve_collateral_t* p_quote_collateral, sgx_ql_qe_report_info_t* p_qve_report_info, const uint8_t* p_user_data, uint32_t user_data_size, uint32_t* p_verification_result_token_buffer_size, uint8_t** p_verification_result_token);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif

--- a/packages/sgx-dcap-quoteverify/sgxssl_stub.c
+++ b/packages/sgx-dcap-quoteverify/sgxssl_stub.c
@@ -1,0 +1,27 @@
+/*
+ * Stub for sgx_usgxssl untrusted library.
+ * The real library provides OCall wrappers for SGXSSL enclaves.
+ * These are only called when running inside an SGX enclave context,
+ * which requires SGX hardware. The quoteverify library loads the
+ * QvE enclave dynamically via dlopen, so these stubs are sufficient
+ * for the non-enclave (QVL) code path.
+ */
+#include <sys/time.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+void u_sgxssl_ftime(void *timeptr, uint32_t timeb_len)
+{
+    (void)timeb_len;
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    /* struct timeb layout: time_t time; unsigned short millitm; ... */
+    memset(timeptr, 0, timeb_len);
+    memcpy(timeptr, &tv.tv_sec, sizeof(tv.tv_sec));
+}
+
+void u_sgxssl_usleep(unsigned int usec)
+{
+    usleep(usec);
+}


### PR DESCRIPTION
Build libsgx_dcap_quoteverify.so independently from the full sgx-dcap package, enabling quote verification on aarch64-linux. The library performs software-only (QVL) quote verification without requiring SGX hardware, making it useful for verifying attestation quotes remotely.

Key approach:
- Use SGX SDK headers from source (arch-independent type definitions)
- Pre-generate edger8r output (qve_u.c/h) to avoid x86 toolchain dep
- Stub sgx_usgxssl (only provides trivial POSIX wrappers for OCall path)
- Use system OpenSSL instead of prebuilt x86 binaries
- Skip QAL/WASM-micro-runtime (appraisal policy engine not needed)