### PR TITLE
fix: install QCNL config file in portable default_qpl output

### DIFF
--- a/packages/sgx-dcap/portable.nix
+++ b/packages/sgx-dcap/portable.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation {
     curl
   ];
 
+  patches = [
+    ./SGXDataCenterAttestationPrimitives-sgx_default_qcnl_conf.patch
+  ];
+
   postPatch = ''
     patchShebangs --build $(find . -name '*.sh')
   ''
@@ -480,6 +484,10 @@ stdenv.mkDerivation {
       ''
   )
   + ''
+
+    # Install QCNL config file
+    mkdir -p $default_qpl/etc
+    cp QuoteGeneration/qcnl/linux/sgx_default_qcnl.conf $default_qpl/etc/
 
     # --- out (default) output — just a placeholder ---
     mkdir -p $out/share/doc


### PR DESCRIPTION
Apply the sgx_default_qcnl_conf patch (pointing to Intel PCS instead of localhost) and install the config to $default_qpl/etc/ so that consumers can reference it via QCNL_CONF_PATH.