### PR TITLE
fix: correct attic cache public key and allow manual CI runs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +34,7 @@ jobs:
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache:uLQovCi1QU+B4PPXhue3z7y2NqznyEJIsGiENpNZtiI=
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache:uBVyXkiuk10QNZcN5y5mIjjtuox79LeIFnqiCzE2TH4=
             substituters = https://cache.nixos.org/ https://attic.teepot.org/cache
             fallback = true
             sandbox = true
@@ -72,7 +73,7 @@ jobs:
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache:uLQovCi1QU+B4PPXhue3z7y2NqznyEJIsGiENpNZtiI=
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache:uBVyXkiuk10QNZcN5y5mIjjtuox79LeIFnqiCzE2TH4=
             substituters = https://cache.nixos.org/ https://attic.teepot.org/cache
             fallback = true
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   nixConfig = {
     extra-substituters = [ "https://attic.teepot.org/cache" ];
-    extra-trusted-public-keys = [ "cache:uLQovCi1QU+B4PPXhue3z7y2NqznyEJIsGiENpNZtiI=" ];
+    extra-trusted-public-keys = [ "cache:uBVyXkiuk10QNZcN5y5mIjjtuox79LeIFnqiCzE2TH4=" ];
   };
 
   inputs = {


### PR DESCRIPTION
The pinned `cache:uLQovCi1...` key did not match the actual signing key on attic.teepot.org/cache, so substituted paths were rejected as untrusted and consumers silently fell back to building from source. Replace it with the real key reported by `attic cache info cache`.

Also add `workflow_dispatch` to nix.yml so the build (and thus attic cache push) can be triggered manually from the Actions UI.