### PR TITLE
ci: build a per-system matrix and gate SGX packages to x86_64-linux

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -27,7 +27,17 @@ jobs:
       - run: nix fmt . -- --ci
 
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            system: x86_64-linux
+          - os: ubuntu-24.04-arm
+            system: aarch64-linux
+          - os: macos-latest
+            system: aarch64-darwin
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: cachix/install-nix-action@v31
@@ -53,36 +63,8 @@ jobs:
         run: nix run github:nixos/nixpkgs/nixos-25.11#nixci -- build
 
       - name: integration check
+        if: matrix.system == 'x86_64-linux'
         run: |
           nix build --accept-flake-config -L .#nixsgx-test-sgx-azure
           docker load -i result
           docker run -i --env GRAMINE_DIRECT=1 --privileged --init --rm nixsgx-test-sgx-azure:latest | grep -q -F 'Hello, world!'
-
-  build-aarch64:
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            system: aarch64-darwin
-          - os: ubuntu-24.04-arm
-            system: aarch64-linux
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ github.token }}
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache:uBVyXkiuk10QNZcN5y5mIjjtuox79LeIFnqiCzE2TH4=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/cache
-            fallback = true
-
-      - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
-        with:
-          endpoint: https://attic.teepot.org/
-          cache: cache
-          token: ${{ secrets.ATTIC_TOKEN }}
-
-      - name: nix build sgx-dcap (portable)
-        run: nix build -L .#sgx-dcap.quote_verify .#sgx-dcap.default_qpl

--- a/overlays/libTee/default.nix
+++ b/overlays/libTee/default.nix
@@ -1,14 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
-{ ... }:
-final: prev: {
-  nixsgxLib.mkSGXContainer = final.lib.warn "`nixsgxLib.mkSGXContainer` is deprecated, use `pkgs.lib.tee.sgxGramineContainer`" final.lib.tee.sgxGramineContainer;
+{ lib, ... }:
+final: prev:
+# `sgxGramineContainer` relies on dockerTools and the SGX/Gramine packages,
+# which are only available on x86_64-linux. Don't expose it elsewhere.
+# The `or false` chain keeps this safe against snowfall's `fake-pkgs` probe,
+# which has neither `stdenv` nor a populated `lib`.
+lib.optionalAttrs
+  ((prev.stdenv.hostPlatform.isx86_64 or false) && (prev.stdenv.hostPlatform.isLinux or false))
+  {
+    nixsgxLib.mkSGXContainer = final.lib.warn "`nixsgxLib.mkSGXContainer` is deprecated, use `pkgs.lib.tee.sgxGramineContainer`" final.lib.tee.sgxGramineContainer;
 
-  lib = prev.lib.extend (
-    libFinal: libPrev: {
-      tee = libPrev.tee or { } // {
-        sgxGramineContainer = args: final.callPackage ./sgxGramineContainer.nix args;
-      };
-    }
-  );
-}
+    lib = prev.lib.extend (
+      libFinal: libPrev: {
+        tee = libPrev.tee or { } // {
+          sgxGramineContainer = args: final.callPackage ./sgxGramineContainer.nix args;
+        };
+      }
+    );
+  }

--- a/packages/nixsgx-test-sgx-dcap/default.nix
+++ b/packages/nixsgx-test-sgx-dcap/default.nix
@@ -2,25 +2,32 @@
 # Copyright (c) 2024 Matter Labs
 {
   pkgs,
+  stdenv,
   hello,
   isAzure ? false,
   container-name ? "nixsgx-test-sgx-dcap",
   tag ? "latest",
 }:
-pkgs.lib.tee.sgxGramineContainer {
-  name = container-name;
-  inherit tag isAzure;
+# `sgxGramineContainer` (and the SGX/Gramine toolchain it relies on) is only
+# available on x86_64-linux. Expose a platform-restricted stub elsewhere so the
+# package still evaluates but is skipped by builds.
+if stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isLinux then
+  pkgs.lib.tee.sgxGramineContainer {
+    name = container-name;
+    inherit tag isAzure;
 
-  packages = [ hello ];
-  entrypoint = pkgs.lib.meta.getExe hello;
+    packages = [ hello ];
+    entrypoint = pkgs.lib.meta.getExe hello;
 
-  extraCmd = "echo \"Starting ${container-name}\"; gramine-sgx-sigstruct-view app.sig";
+    extraCmd = "echo \"Starting ${container-name}\"; gramine-sgx-sigstruct-view app.sig";
 
-  manifest = {
-    sgx = {
-      edmm_enable = false;
-      enclave_size = "32M";
-      max_threads = 4;
+    manifest = {
+      sgx = {
+        edmm_enable = false;
+        enclave_size = "32M";
+        max_threads = 4;
+      };
     };
-  };
-}
+  }
+else
+  pkgs.runCommand container-name { meta.platforms = [ "x86_64-linux" ]; } "exit 1"

--- a/packages/restart-aesmd/default.nix
+++ b/packages/restart-aesmd/default.nix
@@ -3,8 +3,14 @@
   nixsgx,
   ...
 }:
-pkgs.writeShellScriptBin "restart-aesmd" ''
+# Depends on `sgx-psw`, which is only available on x86_64-linux.
+(pkgs.writeShellScriptBin "restart-aesmd" ''
   ${pkgs.coreutils}/bin/mkdir -p /var/run/aesmd
   ${pkgs.killall}/bin/killall -q aesm_service
   exec ${nixsgx.sgx-psw}/bin/aesm_service --no-syslog
-''
+'').overrideAttrs
+  (old: {
+    meta = (old.meta or { }) // {
+      platforms = [ "x86_64-linux" ];
+    };
+  })


### PR DESCRIPTION
Merge the separate `build` and `build-aarch64` jobs into a single matrix over x86_64-linux, aarch64-linux and aarch64-darwin, each running the full `nixci -- build`. The Docker integration test is gated to x86_64-linux, where the Gramine/SGX containers actually exist.

This is only possible now that the flake evaluates and builds cleanly on non-x86_64-linux. To get there:

- overlays/libTee: only expose `lib.tee.sgxGramineContainer` (and the deprecated `nixsgxLib` alias) on x86_64-linux. Uses the overlay's own `lib` and an `or false` platform check so it survives snowfall's `fake-pkgs` probe, which has neither `stdenv` nor a populated `lib`.
- nixsgx-test-sgx-dcap: return a platform-restricted stub on other systems instead of calling the now-absent `sgxGramineContainer`, so it still evaluates and is filtered out of non-x86_64-linux builds.
- restart-aesmd: set `meta.platforms = [ "x86_64-linux" ]` since it embeds `sgx-psw`, otherwise it survived filtering on darwin but could not build.